### PR TITLE
Fix logger init order in login

### DIFF
--- a/login.php
+++ b/login.php
@@ -43,13 +43,13 @@ require_once('includes/ini.php');               //Initialise and load ini file
 require_once('includes/error_handling.php');
 require_once('includes/functions.php');         //Includes basic functions for non-secure pages
 
+// Initialize message object for logging
+$msg = new Message($logfile);
+
 if (!isset($db) || !$db instanceof mysqli) {
     $msg->logMessage('[ERROR]', "Database connection is null or invalid in login.php");
     die("A database error occurred. Please try again later.");
 }
-
-// Initialize message object for logging
-$msg = new Message($logfile);
 
 // Find CSS Version
 $cssver = cssver();


### PR DESCRIPTION
## Summary
- initialise `Message` logger before using it

## Testing
- `php -l login.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68476c6a3ce083239c95ec4283a58eeb