### PR TITLE
Update README Disqus prod url

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Ini file content:
     [comments]
     Disqus         = "disabled"
     DisqusDevURL   = "https://dev-url-here.disqus.com"
-    DisqusDevURL   = "https://prod-url-here.disqus.com"
+    DisqusProdURL   = "https://prod-url-here.disqus.com"
 
 
 Before using:


### PR DESCRIPTION
## Summary
- fix INI file example to use `DisqusProdURL` for the production Disqus URL

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684782f120f48323a8021c8efdd9dc7f