### PR TITLE
Add PHPUnit tests for input interpreter

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1754,6 +1754,8 @@ function input_interpreter($input_string)
                 'foil' => 0,
                 'etched' => 0
             ];
+        else:
+            return false;
         endif;
         return $output;
     endif;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="mtgc">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/InputInterpreterTest.php
+++ b/tests/InputInterpreterTest.php
@@ -1,0 +1,50 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class InputInterpreterTest extends TestCase
+{
+    public function testCsvHeader()
+    {
+        $line = 'set,number,name,lang,normal,foil,etched,uuid';
+        $this->assertSame('header', input_interpreter($line));
+    }
+
+    public function testValidCsvRow()
+    {
+        $line = 'MH3,304,Plains,en,1,0,0,123e4567-e89b-12d3-a456-426614174000';
+        $expected = [
+            'set' => 'MH3',
+            'number' => '304',
+            'name' => 'Plains',
+            'lang' => 'en',
+            'qty' => 1,
+            'uuid' => '123e4567-e89b-12d3-a456-426614174000',
+            'normal' => 1,
+            'foil' => 0,
+            'etched' => 0
+        ];
+        $this->assertSame($expected, input_interpreter($line));
+    }
+
+    public function testNonCsvText()
+    {
+        $line = '2 Plains (MH3) 304';
+        $expected = [
+            'set' => 'MH3',
+            'number' => '304',
+            'name' => 'Plains',
+            'lang' => '',
+            'qty' => 2,
+            'uuid' => '',
+            'normal' => 2,
+            'foil' => 0,
+            'etched' => 0
+        ];
+        $this->assertSame($expected, input_interpreter($line));
+    }
+
+    public function testNoPatternMatches()
+    {
+        $this->assertFalse(input_interpreter('@@@'));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+// Basic bootstrap for tests
+$logfile = sys_get_temp_dir() . '/phpunit.log';
+$loglevelini = 0;
+$db = new class {
+    public function real_escape_string($str) { return $str; }
+};
+$bracketsInNames = [];
+$importLinestoIgnore = [];
+require __DIR__ . '/../classes/message.class.php';
+require __DIR__ . '/../includes/functions.php';


### PR DESCRIPTION
## Summary
- add new PHPUnit test suite and bootstrap
- configure phpunit.xml for the project
- fix `input_interpreter` to return `false` if no pattern matches

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6847874ea32c83238361a11fd703fd2f