### PR TITLE
Add cleanup_tokens cron helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,8 +304,10 @@ Once database is setup and working, manually check and test-run the bulk scripts
 - migrations
 - rulings
 - weekly
+- cleanup_tokens
 
 Setup cron jobs to run each bulk file and also weekly email file from /opt/mtg (run as root) and FX update script. Note the sets.sh file ensures that Apache has write access to the cardimg folder - check path and user.
+Schedule `cleanup_tokens.sh` (or call `cleanup_tokens.php`) via cron—run it daily as the web server user (e.g., `apache`) to remove expired trusted-device entries.
 
 ### PAGE LOAD SEQUENCE ###
 

--- a/setup/cleanup_tokens.sh
+++ b/setup/cleanup_tokens.sh
@@ -1,0 +1,3 @@
+cd /var/www/mtgnew/bulk
+php ./cleanup_tokens.php
+


### PR DESCRIPTION
## Summary
- add setup/cleanup_tokens.sh to run token cleanup via CLI
- document cleanup_tokens job in README

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68481c69bdb88323a89d287c4e2be058