### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM php:8.2-apache
+
+# Install packages required for Composer
+RUN apt-get update && apt-get install -y git unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# Configure Apache DocumentRoot
+ENV APACHE_DOCUMENT_ROOT=/var/www/mtgnew
+RUN sed -ri 's#DocumentRoot /var/www/html#DocumentRoot ${APACHE_DOCUMENT_ROOT}#' /etc/apache2/sites-available/000-default.conf \
+    && sed -ri 's#/var/www/html#${APACHE_DOCUMENT_ROOT}#' /etc/apache2/apache2.conf
+
+# Copy source
+COPY . /var/www/mtgnew
+
+WORKDIR /var/www/mtgnew
+
+# Install PHP dependencies
+RUN composer install --no-dev --no-interaction --prefer-dist
+
+EXPOSE 80
+
+CMD ["apache2-foreground"]

--- a/README.md
+++ b/README.md
@@ -170,6 +170,18 @@ Post-install setup:
 - Make sure the ImgLocation folder (see ini file) exists and is web-server-writable, and is presented to be served as 'cardimg' folder in Apache (I use a soft-link from /opt/mtg/cardimg to a drive with sufficient space)
 - Make sure there is a web-server-readable/writeable json folder in the Imglocation folder (used for scryfall json files)
 
+### Docker ###
+A `Dockerfile` and `docker-compose.yml` are provided to run the site in containers. Copy `setup/mtg_new.ini` to a host folder such as `/opt/mtg` and mount it into the `web` service. Ensure `/var/log/mtg` and the mounted `cardimg` directory are writable by Apache.
+
+Run the containers with:
+
+```bash
+docker-compose up --build
+```
+
+See `docker-compose.override.yml.example` for custom paths or credentials.
+
+
 ### Ini file ###
 - The application expects an ini file located at: /opt/mtg/mtg_new.ini (path can be changed in ini.php if required)
 - Your web server must be able to read AND write this file

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  web:
+    # Example of custom ini file and card image path
+    volumes:
+      - /opt/mtg/mtg_new.ini:/opt/mtg/mtg_new.ini:ro
+      - /srv/cardimg:/mnt/data/cardimg
+    ports:
+      - "8080:80"
+  db:
+    environment:
+      MYSQL_ROOT_PASSWORD: changeme
+      MYSQL_DATABASE: mtg
+      MYSQL_USER: mtg
+      MYSQL_PASSWORD: changeme

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+services:
+  web:
+    build: .
+    ports:
+      - "8080:80"
+    volumes:
+      - ./cardimg:/mnt/data/cardimg
+      - ./opt/mtg:/opt/mtg:ro
+    depends_on:
+      - db
+  db:
+    image: mysql:8
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpass
+      MYSQL_DATABASE: mtg
+      MYSQL_USER: mtg
+      MYSQL_PASSWORD: mtgpass
+    volumes:
+      - db-data:/var/lib/mysql
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- add Dockerfile for PHP 8.2 apache setup
- add docker-compose.yml with web and db services
- provide docker-compose.override.yml.example for overrides
- document Docker usage in README

## Testing
- `composer --version` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6848243a7ab4832382c11840c7f24f5a