### PR TITLE
Add dockerignore for lean builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Ignore Git repository
+.git
+
+# Node modules
+node_modules/
+
+# Tests
+/tests
+
+# Build artifacts and IDE files
+nbproject/
+build/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/
+cardimg/
+.idea/
+
+# Well-known directory
+./well-known
+/.well-known/
+
+# Composer vendor directory and local config
+/vendor
+/includes/sessionname.local.php
+vendor/
+
+# PHP unit cache
+.phpunit.result.cache
+
+# GitHub configuration
+.github/


### PR DESCRIPTION
## Summary
- add `.dockerignore` mirroring `.gitignore` and ignoring tests and other metadata

## Testing
- `docker build -t test-image .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482cb9a6f08323ad30574f57a00321