### PR TITLE
Add Apache config for Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM php:8.2-apache
+
+# Copy application source
+COPY . /var/www/html
+
+# Install site configuration
+COPY setup/mtgc.conf /etc/apache2/sites-available/mtgc.conf
+RUN a2ensite mtgc.conf && a2dissite 000-default.conf
+
+# Entrypoint setup
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["apache2ctl", "-D", "FOREGROUND"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Copy Apache configuration into place
+cp /var/www/html/setup/mtgc.conf /etc/apache2/sites-available/mtgc.conf
+
+# Enable custom site and disable default
+a2ensite mtgc.conf
+a2dissite 000-default.conf
+
+# Reload Apache if running
+apache2ctl -k restart 2>/dev/null || true
+
+exec "$@"


### PR DESCRIPTION
## Summary
- add Dockerfile using php Apache image
- copy and enable mtgc.conf in Docker build
- set up entrypoint script to enable site and restart Apache

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68482d8b3fec8323b1d5b9df7c32ae1c