### PR TITLE
Harden ajax image endpoints with CSRF and validation

### DIFF
--- a/SECURITY_REPORT.md
+++ b/SECURITY_REPORT.md
@@ -1,0 +1,27 @@
+# Security Assessment Report
+
+## Overview
+A brief review of the PHP endpoints identified multiple vulnerabilities that allow remote code execution and file system manipulation without adequate input validation or CSRF protections.
+
+## Findings
+
+### 1. Command injection via set image reload endpoint
+- **Location:** `ajax/ajaxsetimg.php`
+- **Issue:** The `setcode` POST parameter is concatenated directly into a shell command executed with `exec()` without validation or escaping.
+- **Impact:** Authenticated attackers can inject arbitrary shell commands (e.g., `setcode=foo';rm -rf /;#`) executed with the web server's privileges, leading to remote code execution and full server compromise.
+- **Recommendation:** Avoid shelling out; invoke PHP scripts directly. If shell execution is required, validate `setcode` against an allowlist (e.g., `/^[A-Za-z0-9_]+$/`) and use `escapeshellarg()` to quote user input.
+
+### 2. Path traversal in deck photo upload/delete
+- **Location:** `ajax/ajaxphoto.php`
+- **Issue:** The `decknumber` value from POST is used directly to build file paths for uploads and deletions without validation.
+- **Impact:** An attacker can supply path traversal sequences (e.g., `../`) to overwrite or delete arbitrary files writable by the web server, leading to data loss or further code execution.
+- **Recommendation:** Validate `decknumber` with a strict pattern (e.g., `/^[0-9]+$/`), normalize paths, and ensure file operations are confined to the intended `deck_photos` directory.
+
+### 3. Missing CSRF protections on sensitive actions
+- **Location:** `ajax/ajaxphoto.php`, `ajax/ajaxsetimg.php`
+- **Issue:** Both endpoints perform state-changing operations based solely on session cookies and optional `HTTP_REFERER` checks without CSRF tokens.
+- **Impact:** Authenticated users can be tricked via crafted pages into uploading/deleting files or triggering image reloads, leading to unintended actions or privilege escalation if admin accounts are targeted.
+- **Recommendation:** Implement CSRF tokens for all POST endpoints and avoid relying on `HTTP_REFERER`. Consider double-submit or synchronizer token patterns for AJAX requests.
+
+## Conclusion
+The identified issues permit critical exploitation paths (RCE and arbitrary file write/delete). Prioritize remediation by adding robust input validation, eliminating shell injection vectors, and deploying CSRF protections across state-changing endpoints.

--- a/ajax/ajaxphoto.php
+++ b/ajax/ajaxphoto.php
@@ -61,10 +61,24 @@ if ($isValidReferrer):
 
         $response = ['success' => false, 'message' => ''];
 
+        if (!isset($_POST['csrf_token']) || !validateCsrfToken($_POST['csrf_token'])):
+            $msg->logMessage('[ERROR]',"Invalid CSRF token for ajaxphoto");
+            http_response_code(400);
+            $response['message'] = 'Invalid request token';
+            returnResponse();
+        endif;
+
         if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update'])):
             $msg->logMessage('[DEBUG]',"Called with 'update'");
             // Get the deck number from the form data
             $decknumber = isset($_POST['decknumber']) ? $_POST['decknumber'] : '';
+
+            if (!is_string($decknumber) || !preg_match('/^[0-9]+$/', $decknumber)):
+                $msg->logMessage('[ERROR]',"Invalid deck number supplied: '$decknumber'");
+                http_response_code(400);
+                $response['message'] = 'Invalid deck number';
+                returnResponse();
+            endif;
 
             // Check if the file was uploaded without errors and it's a JPEG file
             if (isset($_FILES['photo']) && $_FILES['photo']['error'] === UPLOAD_ERR_OK):
@@ -169,6 +183,13 @@ if ($isValidReferrer):
         elseif ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete'])):
             $msg->logMessage('[DEBUG]',"Called with 'delete'");
             $decknumber = isset($_POST['decknumber']) ? $_POST['decknumber'] : '';
+
+            if (!is_string($decknumber) || !preg_match('/^[0-9]+$/', $decknumber)):
+                $msg->logMessage('[ERROR]',"Invalid deck number supplied for delete: '$decknumber'");
+                http_response_code(400);
+                $response['message'] = 'Invalid deck number';
+                returnResponse();
+            endif;
 
             // Path to the file to be deleted
             $imageFilePath = $ImgLocation.'deck_photos/'.$decknumber.'.jpg';  //File path

--- a/ajax/ajaxsetimg.php
+++ b/ajax/ajaxsetimg.php
@@ -26,24 +26,39 @@ require ('../includes/functions.php');
 include '../includes/colour.php';
 $msg = new Message($logfile);
 
-if (!isset($_SESSION["logged"], $_SESSION['user']) || $_SESSION["logged"] !== TRUE): 
+if (!isset($_SESSION["logged"], $_SESSION['user']) || $_SESSION["logged"] !== TRUE):
     // Return an error in JSON format
     echo json_encode(["status" => "error", "message" => "You are not logged in."]);
     header("Refresh: 2; url=login.php"); // check if the user is logged in; else redirect to login.php
-    exit(); 
-else: 
+    exit();
+else:
+    if (!isset($_POST['csrf_token']) || !validateCsrfToken($_POST['csrf_token'])):
+        $msg->logMessage('[ERROR]',"Invalid CSRF token for ajaxsetimg");
+        http_response_code(400);
+        echo json_encode(["status" => "error", "message" => "Invalid request token"]);
+        exit();
+    endif;
+
     // Need to run these as secpagesetup not run (see page notes)
     $sessionManager = new SessionManager($db, $adminip, $_SESSION, $fxAPI, $fxLocal, $logfile);
     $userArray = $sessionManager->getUserInfo();
     $user = $userArray['usernumber'];
     $mytable = $userArray['table'];
     $useremail = $_SESSION['useremail'];
-    
+
     if (isset($_POST['setcode'])):
         $setcode = $_POST['setcode'];
+        if (!is_string($setcode) || !preg_match('/^[A-Za-z0-9_]+$/', $setcode)):
+            $msg->logMessage('[ERROR]',"Invalid setcode supplied: '$setcode'");
+            http_response_code(400);
+            echo json_encode(["status" => "error", "message" => "Invalid set code supplied"]);
+            exit();
+        endif;
         $root = $_SERVER['DOCUMENT_ROOT'];
         $msg->logMessage('[NOTICE]',"Called with set '$setcode'");
-        $cmd = "php $root/bulk/setimgreload.php '$setcode'> /dev/null 2>&1 &";
+        $safeRoot = escapeshellarg($root . '/bulk/setimgreload.php');
+        $safeSetcode = escapeshellarg($setcode);
+        $cmd = "php $safeRoot $safeSetcode > /dev/null 2>&1 &";
         $msg->logMessage('[NOTICE]',"Running '$cmd'");
         exec($cmd);
         echo json_encode(["status" => "success", "message" => "Image reloading started for set '$setcode' - result will be emailed to server admin"]);

--- a/deckdetail.php
+++ b/deckdetail.php
@@ -3149,11 +3149,13 @@ m13,12,"Fog",en,1,0,0,{id}
                 function deletePhoto() {
                     // Get the deck number
                     var deckNumber = $('input[name="decknumber"]').val();
+                    var csrfToken = <?php echo json_encode(generateCsrfToken()); ?>;
 
                     // Create form data
                     var formData = new FormData();
                     formData.append('decknumber', deckNumber);
                     formData.append('delete', '');
+                    formData.append('csrf_token', csrfToken);
 
                     // Perform AJAX request
                     $.ajax({
@@ -3193,11 +3195,13 @@ m13,12,"Fog",en,1,0,0,{id}
 
                         // Get the deck number from the hidden input
                         var deckNumber = $('input[name="decknumber"]').val();
+                        var csrfToken = <?php echo json_encode(generateCsrfToken()); ?>;
 
                         // Append the deck number to the form data
                         var formData = new FormData(this);
                         formData.append('decknumber', deckNumber);
                         formData.append('update', '');
+                        formData.append('csrf_token', csrfToken);
 
                         $.ajax({
                             url: '/ajax/ajaxphoto.php',

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1416,6 +1416,30 @@ function in_array_case_insensitive($needle, $haystack)
     return false;
 }
 
+/*
+ * Generate (or return existing) CSRF token for the user's session.
+ */
+function generateCsrfToken()
+{
+    if (!isset($_SESSION['csrf_token'])):
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    endif;
+
+    return $_SESSION['csrf_token'];
+}
+
+/*
+ * Validate the submitted CSRF token against the session token.
+ */
+function validateCsrfToken($submittedToken)
+{
+    if (!isset($_SESSION['csrf_token']) || !is_string($submittedToken)):
+        return false;
+    endif;
+
+    return hash_equals($_SESSION['csrf_token'], $submittedToken);
+}
+
 function input_interpreter($input_string)
 // Called by quickAdd in deckmanager class, index.php search inputs and profile.php collection imports
 

--- a/sets.php
+++ b/sets.php
@@ -67,12 +67,14 @@ $msg = new Message($logfile);
     
     ?>
     <script>
+        const csrfToken = <?php echo json_encode(generateCsrfToken()); ?>;
+
         function reloadImages(setcode) {
             document.body.style.cursor = "wait";
             $.ajax({
                 type: 'POST',
                 url: 'ajax/ajaxsetimg.php',
-                data: { setcode: setcode },
+                data: { setcode: setcode, csrf_token: csrfToken },
                 success: function(response) {
                     // Parse the JSON response
                     var result = JSON.parse(response);


### PR DESCRIPTION
## Summary
- add reusable CSRF token helpers and require tokens for ajax image actions
- validate set codes and deck numbers before invoking server-side work to block command injection/path traversal
- propagate CSRF tokens from UI calls to ajax endpoints

## Testing
- php -l ajax/ajaxsetimg.php
- php -l ajax/ajaxphoto.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923a41f15408323bd193b076afe3080)