### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potential fix for [https://github.com/Swallowtail23/mtgc/security/code-scanning/3](https://github.com/Swallowtail23/mtgc/security/code-scanning/3)

In general, the fix is to explicitly declare a `permissions` block for the workflow or the specific job so that the `GITHUB_TOKEN` is restricted to the least privileges needed. For a pure test workflow that only checks out code and runs Composer/PHPUnit, `contents: read` is sufficient in most cases, since no writes to the repository or other resources are required.

The best targeted fix here is to add a `permissions` block to the `test` job in `.github/workflows/phpunit.yml`, immediately under `runs-on: ubuntu-24.04`. This makes the permissions explicit for this job while leaving any other workflows unaffected. The block should specify `contents: read`, which allows checkout of the repository but not write operations. No extra imports or methods are needed, as this is purely a YAML configuration change within the workflow file, and it does not alter the functional steps of the pipeline.

Concretely: in `.github/workflows/phpunit.yml`, edit the `jobs.test` configuration to insert:

```yaml
    permissions:
      contents: read
```

indented to align with `runs-on` and `strategy`. No other lines in the file need to be touched.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
